### PR TITLE
Add Autodoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A list of of AI coding tools (assistants, completion, refactoring, etc.).
 - [Phind](https://www.phind.com/)
 - [Safurai](https://www.safurai.com/)
 - [CensusGPT](https://censusgpt.com/)
+- [Autodoc](https://github.com/context-labs/autodoc)
 
 ## ChatGPT in your editor
 - [CodeGPT.nvim](https://github.com/dpayne/CodeGPT.nvim)


### PR DESCRIPTION
Autodoc is a experimental toolkit for for auto-generating codebase documention for git repositories using Large Language Models, like [GPT-4](https://openai.com/research/gpt-4) or [Alpaca](https://github.com/ggerganov/llama.cpp).