### PR TITLE
Add obsidian-copilot-auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A list of of AI coding tools (assistants, completion, refactoring, etc.).
 - [Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/)
 - [GitLab Code Suggestions](https://docs.gitlab.com/ee/user/project/repository/code_suggestions.html)
 - [Sourcegraph Cody](https://about.sourcegraph.com/cody)
+- [Obsidian copilot auto completion](https://github.com/j0rd1smit/obsidian-copilot-auto-completion)
 
 ## Code completion LLMs
 


### PR DESCRIPTION
Adds [obsidian-copilot-auto-completion](https://github.com/j0rd1smit/obsidian-copilot-auto-completion) to the list.
This adds copilot-like auto-completion to Obsidian, which is a popular markdown-based note-taking application. 

![](https://github.com/j0rd1smit/obsidian-copilot-auto-completion/blob/master/assets/demo-static.gif)