### PR TITLE
Updated list to reflect changes in Amazon Q Developer - name change and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [FauxPilot](https://github.com/fauxpilot/fauxpilot)
 - [CodeComplete](https://codecomplete.ai)
 - [Continue](https://continue.dev/)
-- [Amazon Q Developer]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el))
+- [Amazon Q Developer](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)
 - [GitLab Code Suggestions](https://docs.gitlab.com/ee/user/project/repository/code_suggestions.html)
 - [Sourcegraph Cody](https://about.sourcegraph.com/cody)
 - [Obsidian copilot auto completion](https://github.com/j0rd1smit/obsidian-copilot-auto-completion)
@@ -58,7 +58,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 
 ## AI code review
 - [CodeReviewBot](https://codereviewbot.ai)
-- [Amazon Q Developer - (/review)]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - Amazon Q Developer Agent can review your codebase for security vulnerabilities and code quality issues
+- [Amazon Q Developer (/review)](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - Amazon Q Developer Agent can review your codebase for security vulnerabilities and code quality issues
 
 ## AI code refactoring tools
 
@@ -70,7 +70,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [Resharper](https://www.jetbrains.com/resharper/) - Provides AI-assisted code refactoring for .NET and other languages.
 - [Atomist](https://atomist.com/) - Allows automatic code modification and refactoring through "code transformations."
 - [Test Gru](https://gru.ai/) - Provides enterprise-level unit test automation services.
-- [Amazon Q Developer (/transform]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - Enables you to upgrade Java, .NET, and Cobol code
+- [Amazon Q Developer (/transform)](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - Enables you to upgrade Java, .NET, and Cobol code
 
 ## AI code security
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [FauxPilot](https://github.com/fauxpilot/fauxpilot)
 - [CodeComplete](https://codecomplete.ai)
 - [Continue](https://continue.dev/)
-- [Amazon CodeWhisperer](https://aws.amazon.com/codewhisperer/)
+- [Amazon Q Developer]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el))
 - [GitLab Code Suggestions](https://docs.gitlab.com/ee/user/project/repository/code_suggestions.html)
 - [Sourcegraph Cody](https://about.sourcegraph.com/cody)
 - [Obsidian copilot auto completion](https://github.com/j0rd1smit/obsidian-copilot-auto-completion)
@@ -53,10 +53,12 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [PoorCoder](https://github.com/vgrichina/poorcoder) – set of Unix-style scripts to assist coding using AI apps like Claude, Grok, ChatGPT, etc
 - [Fynix](https://fynix.ai) - AI coding assistant to help developers throughout SDLC.
 - [Memex](https://memex.tech/) - Your desktop AI that turns words into working apps. Native for Mac, Linux, and Windows.
+- [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code. It works with many terminals and shells, on MacOS, Linux and Windows (via wsl).
 
 
 ## AI code review
 - [CodeReviewBot](https://codereviewbot.ai)
+- [Amazon Q Developer - (/review)]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - Amazon Q Developer Agent can review your codebase for security vulnerabilities and code quality issues
 
 ## AI code refactoring tools
 
@@ -68,6 +70,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [Resharper](https://www.jetbrains.com/resharper/) - Provides AI-assisted code refactoring for .NET and other languages.
 - [Atomist](https://atomist.com/) - Allows automatic code modification and refactoring through "code transformations."
 - [Test Gru](https://gru.ai/) - Provides enterprise-level unit test automation services.
+- [Amazon Q Developer (/transform]([https://aws.amazon.com/codewhisperer/](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el)) - Enables you to upgrade Java, .NET, and Cobol code
 
 ## AI code security
 


### PR DESCRIPTION
I updated the list to do the following:

1/ remove the old name of CodeWhisperer and update it to Amazon Q Developer
2/ add /review and /transform in the relevant sections for code review and upgrades
3/ add the new Q Developer CLI tool which is separate (and similar to Aider)