### PR TITLE
Add Havoptic to Similar lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [Awesome-Ai-Agents](https://github.com/e2b-dev/awesome-ai-agents) - Curated list of agents and autonomous agent frameworks.
 - [Awesome-Ai-Tools](https://github.com/ikaijua/Awesome-AITools) - Collection of tools across many categories.
 - [Awesome Ai DevTools](https://github.com/jamesmurdza/awesome-ai-devtools) - Developer-focused tools and resources powered by language models.
+- [Havoptic](https://havoptic.com/) - Release timeline for AI coding tools. Open source.
 
 
 


### PR DESCRIPTION
## Add Havoptic

Adding Havoptic to the Similar lists section.

**Website:** https://havoptic.com  
**Repository:** https://github.com/scotthavird/havoptic.com  
**License:** MIT

**Description:** A free, open-source release timeline for AI coding tools. Aggregates changelogs from tools like Cursor, Codex CLI, Gemini CLI, and others.

Complements this list by helping developers track releases from tools they discover here.