### PR TITLE
Add Open Agent to the list of coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [Cline](https://cline.bot/) - Autonomous coding agent that can use your CLI and editor.
 - [Claude Code](https://www.anthropic.com/claude-code) - Agentic coding tool that lives in your terminal.
 - [Windsurf](https://windsurf.com/) - IDE optimized for collaboration between developers and assistants.
+- [Open Agent](https://github.com/Th0rgal/openagent) - Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [Wizi](https://github.com/wizi-ai/code-search) - Code search across repositories with natural language.
 - [Phind](https://www.phind.com/) - Search engine optimized for developers and technical questions.
 - [Safurai](https://www.safurai.com/) - Assistant for generation, refactoring, and debugging.


### PR DESCRIPTION
Adding [Open Agent](https://github.com/Th0rgal/openagent) to the "Code assistants and search" section.

**What it is:** A self-hosted control plane for Claude Code that provides:
- Isolated container workspaces (via systemd-nspawn) for safe code execution
- - Real-time mission streaming with full event persistence
- - Git-backed Library for skills, tools, rules, and MCPs
- - Web dashboard (Next.js) and iOS app (SwiftUI)
**Tech:** Rust/Axum backend, Apache 2.0 license, actively maintained.