### PR TITLE
Add Tokscale to Code assistants and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [Augment](https://www.augmentcode.com/) - Context-aware completions for enterprise teams.
 - [Poolside](https://poolside.ai/) - Assistant specialized in software engineering tasks.
 - [Sourcegraph Amp](https://ampcode.com/) - Agent that helps you build, debug, and understand code.
+- [Tokscale](https://github.com/junhoyeo/tokscale) - CLI for tracking token usage across AI coding agents (Claude Code, OpenClaw, Codex, Gemini CLI, Cursor, AmpCode) with global leaderboard and contribution graphs.
 
 
 ## Code review


### PR DESCRIPTION
## Summary

Adding [Tokscale](https://github.com/junhoyeo/tokscale) to the **Code assistants and search** section.

**Tokscale** is a CLI for tracking token usage across AI coding agents including Claude Code, OpenClaw, Codex, Gemini CLI, Cursor, and AmpCode.

**Features:**
- Global leaderboard for usage comparison
- 2D/3D contribution graphs
- Multi-agent support

**Stats:** 500+ GitHub stars

This helps developers monitor their AI coding assistant usage across multiple tools.