### PR TITLE
Add debug-mcp.net to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 
 ## Model Context Protocol (MCP)
 
+- [debug-mcp.net](https://github.com/jkolo/debug-mcp) – MCP server for .NET debugging with 34 AI-accessible tools via ICorDebug APIs.
 - [Roundtable MCP Server](https://github.com/askbudi/roundtable) – Zero-configuration MCP server that unifies multiple coding assistants (Codex, Claude Code, Cursor, Gemini) through auto-discovery and a standard interface.
 - [ToolHive](https://github.com/stacklok/toolhive) – Helps find the right MCP server for your task and deploy it with one click.
 


### PR DESCRIPTION
[debug-mcp.net](https://github.com/jkolo/debug-mcp) is an MCP server for .NET debugging with 34 AI-accessible tools via ICorDebug APIs. It enables AI agents to launch processes, set breakpoints, step through code, inspect variables, evaluate expressions, and analyze exceptions.

- **Website**: https://debug-mcp.net
- **License**: AGPL-3.0
- **Language**: C# / .NET 10

Entry placed alphabetically in the Model Context Protocol (MCP) section.