### PR TITLE
Add CursorRules Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 
 ## Code assistants and search
 
-- [Replit Ghostwriter](https://replit.com/site/ghostwriter) - Embedded assistant in Replit’s IDE for suggestions and edits.
+- [Replit Ghostwriter](https://replit.com/site/ghostwriter) - Embedded assistant in Replit's IDE for suggestions and edits.
 - [Capacity](https://capacity.so) - Platform for automating support and workflows with conversational interfaces.
 - [Cosine](https://ai.cosine.sh/) - Assistant that understands your codebase for accurate generation.
 - [Cursor](https://www.cursor.sh/) - Code editor built for pair programming with a language model.
@@ -91,9 +91,14 @@ A list of AI coding tools (assistants, completion, refactoring, etc.).
 - [JetBrains Qodana](https://www.jetbrains.com/qodana/) - Automated refactoring, security checks, and technical debt management.
 - [Tabnine](https://www.tabnine.com/) - Suggests improvements that support refactoring flows.
 - [Resharper](https://www.jetbrains.com/resharper/) - Refactoring support for .NET and other languages.
-- [Atomist](https://atomist.com/) - Automatic code modification and refactoring via “code transformations.”
+- [Atomist](https://atomist.com/) - Automatic code modification and refactoring via "code transformations."
 - [Test Gru](https://gru.ai/) - Enterprise-level unit test automation services.
 - [Amazon Q Developer (/transform)](https://aws.amazon.com/q/developer/build/?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - Helps upgrade Java, .NET, and Cobol code.
+
+
+## Configuration and Setup Tools
+
+- [CursorRules Pro](https://github.com/Wittlesus/cursorrules-pro) - Pre-built .cursorrules configurations for 8 popular frameworks (React, Next.js, Vue, Python, etc.). Works with Cursor, Cline, Windsurf, and Claude Code to provide framework-specific AI assistant behavior.
 
 
 ## Model Context Protocol (MCP)


### PR DESCRIPTION
Hi! I'd like to add **CursorRules Pro** to this awesome list.

**What is it?**
CursorRules Pro is a collection of pre-built `.cursorrules` configuration files for popular frameworks and languages. These configuration files customize the behavior of AI coding assistants like Cursor, Cline, Windsurf, and Claude Code to provide framework-specific suggestions and best practices.

**What it includes:**
- Pre-configured rules for 8 frameworks: React, Next.js, Vue, Svelte, Python, Node.js, Django, and Go
- Framework-specific coding standards and patterns
- Works with multiple AI coding tools that support .cursorrules files

**Why include it?**
While this list contains many excellent AI coding tools, CursorRules Pro helps developers get more value from those tools by providing framework-specific configuration. It bridges the gap between generic AI assistants and specialized, context-aware coding support.

**Where I added it:**
I created a new "Configuration and Setup Tools" section, as .cursorrules files are configuration resources that enhance existing AI coding tools rather than being standalone tools themselves.

The project is actively maintained and available at https://github.com/Wittlesus/cursorrules-pro.

**Note:** I understand this repository is archived, but I wanted to submit this contribution in case it's still being considered for inclusion.

Thank you for creating and maintaining this valuable resource!